### PR TITLE
OpenVPN config cannot be read due to bashio error

### DIFF
--- a/transmission-nas/rootfs/etc/cont-init.d/10-requirements.sh
+++ b/transmission-nas/rootfs/etc/cont-init.d/10-requirements.sh
@@ -6,25 +6,30 @@
 # Check authentication requirements, if enabled
 if bashio::config.true 'authentication_required'; then
     if ! bashio::config.has_value 'username'; then
-        bashio::die 'Transmission authentication is enabled, but no username was specified'
+        bashio::log.fatal 'Transmission authentication is enabled, but no username was specified'
+        bashio::exit.nok
     fi
 
     if ! bashio::config.has_value 'password'; then
-        bashio::die 'Transmission authentication is enabled, but no password was specified'
+        bashio::log.fatal 'Transmission authentication is enabled, but no password was specified'
+        bashio::exit.nok
     fi
 fi
 
 # Check OpenVPN requirements, if enabled
 if bashio::config.true 'openvpn_enabled'; then
     if ! bashio::config.has_value 'openvpn_username'; then
-        bashio::die 'OpenVPN is enabled, but no username was specified'
+        bashio::log.fatal 'OpenVPN is enabled, but no username was specified'
+        bashio::exit.nok
     fi
 
     if ! bashio::config.has_value 'openvpn_password'; then
-        bashio::die 'OpenVPN is enabled, but no password was specified'
+        bashio::log.fatal 'OpenVPN is enabled, but no password was specified'
+        bashio::exit.nok
     fi
 
-    if ! bashio::file_exists "/config/openvpn/$(bashio::config.get 'openvpn_config').ovpn"; then
-        bashio::die "The configured /config/openvpn/$(bashio::config.get 'openvpn_config').ovpn file is not found"
+    if ! bashio::fs.file_exists "/config/openvpn/$(bashio::config 'openvpn_config').ovpn"; then
+        bashio::log.fatal "The configured /config/openvpn/$(bashio::config 'openvpn_config').ovpn file is not found"
+        bashio::exit.nok
     fi
 fi


### PR DESCRIPTION
Cherry-picked the relevant commit on #1 (from @bucketybuckbuck ) and rebased with the current master due to conflicts.